### PR TITLE
Add system flag to zookeeper user

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -84,7 +84,9 @@ def zk_dependency_gems
 end
 
 def zk_user_resource(user='')
-  return Chef::Resource::User.new(user, @run_context)
+  u = Chef::Resource::User.new(user, @run_context)
+  u.system(true)
+  return u
 end
 
 def zk_group_resource(group='')


### PR DESCRIPTION
In my world, we nuke all non-system accounts that weren't added by our centralized management tools, so I put this change in and thought I'd submit it to see if you thought it was a good idea too.

Thanks, and have fun!
