### PR TITLE
Always include build-essential

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -15,13 +15,14 @@
 # limitations under the License.
 
 if node[:zookeeper][:use_java_cookbook] == true
-  node.override['build-essential']['compile_time'] = true
-
-  include_recipe 'build-essential::default'
   include_recipe 'java::default'
 else
   Chef::Log.info("Assuming you've provided your own Java")
 end
+
+# build-essential is required to build the zookeeper and json gems
+node.override['build-essential']['compile_time'] = true
+include_recipe 'build-essential::default'
 
 zookeeper node[:zookeeper][:version] do
   user        node[:zookeeper][:user]


### PR DESCRIPTION
Build tools including GCC, patch, etc must be installed in order to
build the zookeeper and json gems.  `build-essential` handles this in
the `install` recipe, however the `build-essential` recipe is *only*
included when the `use_java_cookbook` attribute is set to `true`.

This patch unconditionally includes the `build-essential` recipe.

This was previously addressed in the `exhibitor` recipe for issue #73/#74,
however the exhibitor recipe no longer exists.

Tested with CentOS 6.6 and Ubuntu 14.04.