### PR TITLE
Fixes zookeeper_node and zookeeper::service with runit

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,5 +13,5 @@ suites:
   - name: default
     run_list:
       - recipe[apt::default]
-      - recipe[zookeeper::default]
+      - recipe[zookeeper_tester]
     attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,5 @@ metadata
 
 group :integration do
   cookbook 'apt'
+  cookbook 'zookeeper_tester', path: 'test/cookbooks/zookeeper_tester'
 end

--- a/README.md
+++ b/README.md
@@ -90,6 +90,25 @@ zookeeper_config '/opt/zookeeper/zookeeper-3.4.6/conf/zoo.cfg' do
 end
 ```
 
+#### zookeeper_node
+This resource can create nodes in Zookeeper.
+
+Actions: `:create`, `:create_if_missing`, `:delete`
+
+Parameters:
+* `path`: The user to give ownership of the file to (default: The name of the resource)
+* `connect_str`: Hash of configuration parameters to add to the file (required)
+* `data`: The data to write to in the node
+
+Example:
+``` ruby
+zookeeper_node '/data/myNode' do
+  action :create
+  connect_str "localhost:2181"
+  data "my data"
+end
+```
+
 ## Errata
 * Version 1.4.7 on the community site is in fact version 1.4.8.
 

--- a/providers/node.rb
+++ b/providers/node.rb
@@ -18,7 +18,7 @@ def zookeeper
   require 'zookeeper'
 
   @zookeeper ||= begin
-    Zookeeper.new(@new_resource.connect_str)
+    ::Zookeeper.new(@new_resource.connect_str)
   end
 end
 

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# download and install base package
+include_recipe 'zookeeper::install'
+
+# set config path and render config
+include_recipe 'zookeeper::config_render'
+
 executable_path = ::File.join(node[:zookeeper][:install_dir],
                               "zookeeper-#{node[:zookeeper][:version]}",
                               'bin',
@@ -43,6 +49,9 @@ when 'upstart'
     action :enable
   end
 when 'runit'
+  # runit_service does not install runit itself
+  include_recipe "runit"
+
   runit_service 'zookeeper' do
     default_logger true
     options(

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -14,12 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# download and install base package
-include_recipe 'zookeeper::install'
-
-# set config path and render config
-include_recipe 'zookeeper::config_render'
-
 executable_path = ::File.join(node[:zookeeper][:install_dir],
                               "zookeeper-#{node[:zookeeper][:version]}",
                               'bin',

--- a/test/cookbooks/zookeeper_tester/README.md
+++ b/test/cookbooks/zookeeper_tester/README.md
@@ -1,0 +1,4 @@
+zookeeper_tester Cookbook
+=========================
+
+A cookbook to test the zookeeper cookbook's resources/providers

--- a/test/cookbooks/zookeeper_tester/metadata.rb
+++ b/test/cookbooks/zookeeper_tester/metadata.rb
@@ -1,0 +1,9 @@
+name             'zookeeper_tester'
+maintainer       'YOUR_COMPANY_NAME'
+maintainer_email 'YOUR_EMAIL'
+license          'All rights reserved'
+description      'Installs/Configures zookeeper_tester'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+
+depends 'zookeeper'

--- a/test/cookbooks/zookeeper_tester/recipes/default.rb
+++ b/test/cookbooks/zookeeper_tester/recipes/default.rb
@@ -1,0 +1,7 @@
+
+include_recipe "zookeeper::service"
+
+zookeeper_node "/testing" do
+  connect_str "localhost:2181"
+  data "some data"
+end

--- a/test/cookbooks/zookeeper_tester/recipes/default.rb
+++ b/test/cookbooks/zookeeper_tester/recipes/default.rb
@@ -1,4 +1,5 @@
 
+include_recipe "zookeeper"
 include_recipe "zookeeper::service"
 
 zookeeper_node "/testing" do

--- a/test/integration/default/serverspec/Gemfile
+++ b/test/integration/default/serverspec/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'zookeeper', '~> 1.4'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,22 @@
+# coding: UTF-8
+
+require 'spec_helper'
+
+describe service('zookeeper') do
+  it { should be_running   }
+end
+
+describe port(2181) do
+  it { should be_listening }
+end
+
+describe 'zookeeper_node' do
+
+  it 'should create /testing' do
+    zookeeper = Zookeeper.new("localhost:2181")
+    data = zookeeper.get(:path => "/testing")
+    expect(data[:stat].exists?).to eq(true)
+    expect(data[:data]).to eq("some data")
+  end
+
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,12 @@
+# coding: UTF-8
+
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec
+
+# Something we need in order to get 'describe server' to work
+set :path, '/sbin:/usr/local/sbin:$PATH'
+
+# Used by testing
+require 'zookeeper'


### PR DESCRIPTION
Originally started this to fix a namespace issue with the zookeeper_node provider referencing the zookeeper provider instead of the zookeeper client.

The other fixes were surprises I found when setting up testing for this