### PR TITLE
Add ability to configure znode ACL via node LWRP

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Parameters:
 * `data`: The data to write to the node
 * `auth_scheme`: The authentication scheme (default: digest)
 * `auth_cert`: The authentication password or data
+* `acl_digest`: Hash of acl permissions per 'digest' id
+* `acl_ip`: Hash of acl permissions per 'ip'
+* `acl_sasl`: Hash of acl permissions per 'sasl' id (SASLAuthentication provider must be enabled)
+* `acl_world`: Acl permissions for anyone (default: `Zk::PERM_ALL`)
 
 Example:
 ``` ruby
@@ -116,6 +120,9 @@ zookeeper_node '/data/myNode' do
   auth_scheme  "digest"
   auth_cert    "user1:pwd1"
   acl_digest   "user1:a9l5yfb9zl8WCXjVmi5/XOC0Ep4=" => Zk::PERM_ALL
+  acl_ip       "127.0.0.1" => Zk::PERM_READ | Zk::PERM_WRITE
+  acl_sasl     "user@CHEF.IO" => Zk::PERM_ADMIN
+  acl_world    Zk::PERM_NONE
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,18 @@ Parameters:
 * `path`: The zookeeper node path (default: The name of the resource)
 * `connect_str`: The zookeeper connection string (required)
 * `data`: The data to write to the node
+* `auth_scheme`: The authentication scheme (default: digest)
+* `auth_cert`: The authentication password or data
 
 Example:
 ``` ruby
 zookeeper_node '/data/myNode' do
   action :create
-  connect_str "localhost:2181"
-  data "my data"
+  connect_str  "localhost:2181"
+  data         "my data"
+  auth_scheme  "digest"
+  auth_cert    "user1:pwd1"
+  acl_digest   "user1:a9l5yfb9zl8WCXjVmi5/XOC0Ep4=" => Zk::PERM_ALL
 end
 ```
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,6 +1,45 @@
 # libraries/default.rb
 
 module Zk
+  PERM_NONE   = 0x00
+  PERM_READ   = 0x01
+  PERM_WRITE  = 0x02
+  PERM_CREATE = 0x04
+  PERM_DELETE = 0x08
+  PERM_ADMIN  = 0x10
+  PERM_ALL    = PERM_READ | PERM_WRITE | PERM_CREATE | PERM_DELETE | PERM_ADMIN
+
+  def self.error_message(error_code)
+    case error_code
+      when -1 then 'System error'
+      when -2 then 'Runtime inconsistency'
+      when -3 then 'Data inconsistency'
+      when -4 then 'Connection loss'
+      when -5 then 'Marshalling error'
+      when -6 then 'Unimplemented'
+      when -7 then 'Operation timeout'
+      when -8 then 'Bad arguments'
+      when -13 then 'New config no Quorum'
+      when -14 then 'Another reconfiguration is in progress'
+      when -100 then 'Api errors'
+      when -101 then 'Node does not exists'
+      when -102 then 'No authentication'
+      when -103 then 'Bad version'
+      when -108 then 'No children for ephemerals'
+      when -110 then 'Node already exists'
+      when -111 then 'Node not empty'
+      when -112 then 'Session has expired'
+      when -113 then 'Invalid callback'
+      when -114 then 'Invalid acl'
+      when -115 then 'Authentication has failed'
+      when -118 then 'Session has moved'
+      when -119 then 'This server does not support read only'
+      when -120 then 'Attempt to create ephemeral node on a local session'
+      when -121 then 'Attempts to remove a non-existing watcher'
+      else 'Unknown'
+    end
+  end
+
   module Config
     # Zookeeper uses a Java properties file style of configuration. This helper
     # method will render a hash in that style.

--- a/providers/node.rb
+++ b/providers/node.rb
@@ -16,9 +16,8 @@
 
 def zookeeper
   require 'zookeeper'
-
-  @zookeeper ||= begin
-    ::Zookeeper.new(@new_resource.connect_str)
+  @zookeeper ||= ::Zookeeper.new(new_resource.connect_str).tap do |zk|
+    zk.add_auth(scheme: new_resource.auth_scheme, cert: new_resource.auth_cert) unless new_resource.auth_cert.nil?
   end
 end
 

--- a/resources/node.rb
+++ b/resources/node.rb
@@ -23,3 +23,18 @@ attribute :data,        kind_of: String
 
 attribute :auth_cert,   kind_of: String, default: nil
 attribute :auth_scheme, kind_of: String, default: 'digest'
+
+attribute :acl_digest,  kind_of: Hash
+attribute :acl_ip,      kind_of: Hash
+attribute :acl_sasl,    kind_of: Hash
+attribute :acl_world,   kind_of: Fixnum, default: Zk::PERM_ALL
+
+def initialize(name, run_context = nil)
+  super
+
+  # Initializes acl attributes default values
+  # We can't use `default` dsl because it'll share the hash reference
+  @acl_digest = {}
+  @acl_sasl = {}
+  @acl_ip = {}
+end

--- a/resources/node.rb
+++ b/resources/node.rb
@@ -20,3 +20,6 @@ default_action(:create)
 attribute :path,        kind_of: String, name_attribute: true
 attribute :connect_str, kind_of: String, required: true
 attribute :data,        kind_of: String
+
+attribute :auth_cert,   kind_of: String, default: nil
+attribute :auth_scheme, kind_of: String, default: 'digest'

--- a/test/cookbooks/zookeeper_tester/recipes/default.rb
+++ b/test/cookbooks/zookeeper_tester/recipes/default.rb
@@ -6,3 +6,13 @@ zookeeper_node "/testing" do
   connect_str "localhost:2181"
   data "some data"
 end
+
+zookeeper_node "/secure" do
+  connect_str  "localhost:2181"
+  data         "sensitive data"
+  auth_scheme  "digest"
+  auth_cert    "user1:pwd1"
+  acl_digest   "user1:a9l5yfb9zl8WCXjVmi5/XOC0Ep4=" => Zk::PERM_ALL
+  acl_ip       "127.0.0.1" => Zk::PERM_READ | Zk::PERM_WRITE
+  acl_world    Zk::PERM_NONE
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -18,5 +18,18 @@ context 'when all attributes are default' do
       expect(data[:stat].exists?).to eq true
       expect(data[:data]).to eq 'some data'
     end
+
+    it 'should create /secure with correct ACLs' do
+      expected_acls = [
+        { perms: 31, id: { scheme: 'digest', id: 'user1:a9l5yfb9zl8WCXjVmi5/XOC0Ep4=' } },
+        { perms: 3, id: { scheme: 'ip', id: '127.0.0.1' } },
+        { perms: 0, id: { scheme: 'world', id: 'anyone' } },
+      ]
+
+      zookeeper = Zookeeper.new 'localhost:2181'
+      result = zookeeper.get_acl path: '/secure'
+      expect(result[:stat].exists?).to eq true
+      expect(result[:acl]).to match_array expected_acls
+    end
   end
 end


### PR DESCRIPTION
Zookeeper nodes have an ACL system not configured by the LWRP.
This PR add ability to configure these ACLs using multiples scheme (digest, world, sasl, ip, host)
It also adds authentication support to connect to zookeeper.

cc. @aboten