### PR TITLE
Fixed setting/interpolation of default[:zookeeper][:config_dir] attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,7 +9,7 @@ default[:zookeeper][:user]        = 'zookeeper'
 default[:zookeeper][:install_dir] = '/opt/zookeeper'
 default[:zookeeper][:use_java_cookbook] = true
 default[:zookeeper][:config_dir]  = "#{node[:zookeeper][:install_dir]}/" \
-                                    'zookeeper-%{zookeeper_version}/conf'
+                                    "zookeeper-#{node[:zookeeper][:version]}/conf"
 default[:zookeeper][:conf_file]   = 'zoo.cfg'
 default[:zookeeper][:java_opts] = "-Xms128M -Xmx512M"
 default[:zookeeper][:log_dir]     = "/var/log/zookeeper"

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Simple Finance Technology Corp.'
 maintainer_email 'ops@simple.com'
 license          'Apache v2.0'
 description      'Installs/Configures zookeeper'
-version          '3.0.2'
+version          '3.0.3'
 
 supports         'ubuntu', '= 12.04'
 supports         'ubuntu', '= 14.04'


### PR DESCRIPTION
It seems that now `default[:zookeeper][:config_dir]` is set the way it ends up like this on node:
`config_dir: /opt/zookeeper/zookeeper-%{zookeeper_version}/conf`. The `zookeeper_version` variable is never set in `attributes/default.rb`. Referencing `node[:zookeeper][:config_dir]` in wrapper cookbook ie. causes errors.

Also patch level version bump of cookbook.